### PR TITLE
Fixed peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/mentatxx/class-validator-is-nullable#readme",
   "peerDependencies": {
-    "class-validator": "^0.8.5"
+    "class-validator": "^0.11.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",


### PR DESCRIPTION
`warning " > class-validator-is-nullable@0.8.7" has incorrect peer dependency "class-validator@^0.8.5".
`
Works fine on 0.11.0, so I suggest to update peerDependencies